### PR TITLE
Port part of index.js to mdx-index.mdx

### DIFF
--- a/content/CopyLargeImageLeftText.mdx
+++ b/content/CopyLargeImageLeftText.mdx
@@ -1,0 +1,25 @@
+Creating dynamic and interactive data visualizations on the web is a pain in the
+ass. It gets really hard when you add animation, inter-connected dashboards, and
+fast performance on mobile devices.
+
+You're either using libraries you can't customize, copy pasting D3 examples you
+don't understand, or battling documentation to write spaghetti code you can't
+reuse.
+
+It's okay, we've all been there.
+
+But it doesn't have to be that way.
+
+With React+D3v4 you'll learn the basics of building fast data visualization
+components in about an hour. Get started immediately without installing
+anything.
+
+Don't know React? React+D3v4 starts at the very beginning.
+
+Struggling with D3? Every function is explained.
+
+New to modern JavaScript syntax? React+D3v4 comes with an interactive ES6
+cheatsheet.
+
+Get the confidence you need to excell. <span role="img"
+aria-label="so cool">💪</span>

--- a/content/CopyLargeImageRightText.mdx
+++ b/content/CopyLargeImageRightText.mdx
@@ -1,0 +1,6 @@
+import CopyLargeImageLeftText from 'CopyLargeImageLeftText'
+import ReadChapter from '../src/widgets/ReadChapter'
+
+<CopyLargeImageLeftText />
+
+<ReadChapter />

--- a/package-lock.json
+++ b/package-lock.json
@@ -682,6 +682,13 @@
       "requires": {
         "core-js": "^2.5.7",
         "regenerator-runtime": "^0.11.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        }
       }
     },
     "@babel/preset-env": {
@@ -827,6 +834,40 @@
         }
       }
     },
+    "@emotion/cache": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-0.8.7.tgz",
+      "integrity": "sha512-pUT4w5JQIpZ3bhuhzmJopBq2B4HajgofKYD/NAoS1eolk2AM7O4pIelCWfEn3GwbLBpe4dtv+RJfsI+1+HDY0w==",
+      "dev": true,
+      "requires": {
+        "@emotion/sheet": "^0.8.0",
+        "@emotion/stylis": "^0.7.0",
+        "@emotion/utils": "^0.8.1"
+      }
+    },
+    "@emotion/core": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-0.13.0.tgz",
+      "integrity": "sha512-WW5ks5RxAair9iqvsA7b8lMe5gszdAlBA8iFS/gXUeCKlGYaONDaJ+zswPnTi0VVDPz5jPAqKT140bg9NxS4kA==",
+      "dev": true,
+      "requires": {
+        "@emotion/cache": "^0.8.7",
+        "@emotion/css": "^0.9.7",
+        "@emotion/serialize": "^0.9.0",
+        "@emotion/sheet": "^0.8.0",
+        "@emotion/utils": "^0.8.1"
+      }
+    },
+    "@emotion/css": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-0.9.7.tgz",
+      "integrity": "sha512-Axrw7Xe0HF+e/JwS4eqqlV5PcHEDsYgZdPn9IPZT9F17XRXQPWq0H0eHUUoiMtwtxdKX+2I4Gy0+4jOS7xaMSA==",
+      "dev": true,
+      "requires": {
+        "@emotion/serialize": "^0.9.0",
+        "@emotion/utils": "^0.8.1"
+      }
+    },
     "@emotion/hash": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.5.tgz",
@@ -834,10 +875,9 @@
       "dev": true
     },
     "@emotion/is-prop-valid": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.6.6.tgz",
-      "integrity": "sha512-T6Bo3dtUJctwZ1I8kFdlkTVtcKU2XqVMsbzMKlDJaFDIyaxjWYpa6J4cGVp+OfC59CD1cxunbIwr9vzBammYsg==",
-      "dev": true,
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.6.7.tgz",
+      "integrity": "sha512-cK5YUueFhAff0GqL5PqPruBCSdiQ9Gatuc2p7uHOsXh1hx+4aKLF3frPSTobFElwlGUypVwF5pjB3hhc7DebjQ==",
       "requires": {
         "@emotion/memoize": "^0.6.5"
       }
@@ -845,8 +885,17 @@
     "@emotion/memoize": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.5.tgz",
-      "integrity": "sha512-n1USr7yICA4LFIv7z6kKsXM8rZJxd1btKCBmDewlit+3OJ2j4bDfgXTAxTHYbPkHS/eztHmFWfsbxW2Pu5mDqA==",
-      "dev": true
+      "integrity": "sha512-n1USr7yICA4LFIv7z6kKsXM8rZJxd1btKCBmDewlit+3OJ2j4bDfgXTAxTHYbPkHS/eztHmFWfsbxW2Pu5mDqA=="
+    },
+    "@emotion/provider": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@emotion/provider/-/provider-0.11.1.tgz",
+      "integrity": "sha512-BIjZ1Z96IJCEHv090b/xaOPnDvCfCG1N+ZjtF/dTRCeX/AT+ICqVG3XPzJPEEJHz8z1XNqLg7Cfn9GaQsiTc+Q==",
+      "dev": true,
+      "requires": {
+        "@emotion/cache": "^0.8.7",
+        "@emotion/weak-memoize": "^0.1.2"
+      }
     },
     "@emotion/serialize": {
       "version": "0.9.0",
@@ -857,6 +906,32 @@
         "@emotion/hash": "^0.6.5",
         "@emotion/memoize": "^0.6.5",
         "@emotion/unitless": "^0.6.6",
+        "@emotion/utils": "^0.8.1"
+      }
+    },
+    "@emotion/sheet": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.8.0.tgz",
+      "integrity": "sha512-r0chioZtpS/OYKrMNTf/EHPPKpN5ue1jY8OZkoVzYkRjK3dS4NNNQIcIlr0wNFmkMl+dRTk5hlXrb7VnYGPqaA==",
+      "dev": true
+    },
+    "@emotion/styled": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-0.10.5.tgz",
+      "integrity": "sha512-RU2yXD90Seh+GPGm84Z7KPw+yf/hqasOZg5ikeFizcyII18JPsHJMJEDpwJdMSeB8o3ORyceyFrSaIkNR7mhpA==",
+      "dev": true,
+      "requires": {
+        "@emotion/styled-base": "^0.10.5"
+      }
+    },
+    "@emotion/styled-base": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-0.10.5.tgz",
+      "integrity": "sha512-7XnIosgeJ/jlXlU/OBhXlVuoTk4HOxdznBc08pdkZs8EzSSIu7ASMbDIViylmCVIND7Qhrk4JVbXrM0I/4OpmA==",
+      "dev": true,
+      "requires": {
+        "@emotion/is-prop-valid": "^0.6.7",
+        "@emotion/serialize": "^0.9.0",
         "@emotion/utils": "^0.8.1"
       }
     },
@@ -876,6 +951,12 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.1.tgz",
       "integrity": "sha512-dEv1n+IFtlvLQ8/FsTOtBCC1aNT4B5abE8ODF5wk2tpWnjvgGNRMvHCeJGbVHjFfer4h8MH2w9c2/6eoJHclMg==",
+      "dev": true
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.1.2.tgz",
+      "integrity": "sha512-KZE0Nwk3N/2rszlX1VGhJKzM2OduGVMckIu59f5EEY33dH2ngbCYQyByQk1c2qUfBcFUWycyle/corEyNfodxg==",
       "dev": true
     },
     "@glimmer/interfaces": {
@@ -952,33 +1033,24 @@
       }
     },
     "@ndelangen/react-treebeard": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@ndelangen/react-treebeard/-/react-treebeard-2.1.0.tgz",
-      "integrity": "sha512-1xFFS2IYLvaEZo5PnkDiJALSljS3u8gR7dovn3CIr0W160ZJNGwU49qaC05T9WaBaybnhT8PSh0SywzCOeSlpg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ndelangen/react-treebeard/-/react-treebeard-3.0.0.tgz",
+      "integrity": "sha512-0ZIboPhpqkOUOjlILHIPLAaaQVVrLqYqN7LnzZYxxmMhqVKCDz+VVcTWFn8L3vzDWUW6SzT0L+UA0obQcB+O+g==",
       "dev": true,
       "requires": {
+        "@emotion/core": "0.13.0",
+        "@emotion/styled": "0.10.5",
         "babel-runtime": "^6.23.0",
         "deep-equal": "^1.0.1",
-        "prop-types": "^15.5.8",
-        "shallowequal": "^0.2.2",
+        "prop-types": "^15.6.2",
+        "shallowequal": "^1.1.0",
         "velocity-react": "^1.3.1"
-      },
-      "dependencies": {
-        "shallowequal": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz",
-          "integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
-          "dev": true,
-          "requires": {
-            "lodash.keys": "^3.1.2"
-          }
-        }
       }
     },
     "@nodelib/fs.stat": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.1.tgz",
-      "integrity": "sha512-KU/VDjC5RwtDUZiz3d+DHXJF2lp5hB9dn552TXIyptj8SH1vXmR40mG0JgGq03IlYsOgGfcv8xrLpSQ0YUMQdA=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz",
+      "integrity": "sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw=="
     },
     "@reach/router": {
       "version": "1.1.1",
@@ -993,73 +1065,74 @@
       }
     },
     "@storybook/addon-actions": {
-      "version": "4.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-4.0.0-alpha.18.tgz",
-      "integrity": "sha512-pRtidl5SPYfOg5H4bUr0yGTchF9+gN44WfQ9TD05qpmcBnEKeepOmdKoKApKxHUUs45Wao+SITceCc4bCxc+ZA==",
+      "version": "4.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-4.0.0-alpha.20.tgz",
+      "integrity": "sha512-XlRNvDaAg+GXyehjj/K4OwotXpZ0HvpYBWrYaRo2IURJXeANsmuVsOmNCcf1kEaa5M+v8IlXnIrGuCDDwBwm0g==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "4.0.0-alpha.18",
-        "@storybook/components": "4.0.0-alpha.18",
-        "@storybook/core-events": "4.0.0-alpha.18",
+        "@emotion/core": "^0.13.0",
+        "@emotion/provider": "0.11.1",
+        "@emotion/styled": "0.10.5",
+        "@storybook/addons": "4.0.0-alpha.20",
+        "@storybook/components": "4.0.0-alpha.20",
+        "@storybook/core-events": "4.0.0-alpha.20",
         "deep-equal": "^1.0.1",
-        "emotion-theming": "^9.2.6",
         "global": "^4.3.2",
         "lodash.isequal": "^4.5.0",
-        "make-error": "^1.3.4",
+        "make-error": "^1.3.5",
         "prop-types": "^15.6.2",
-        "react-emotion": "^9.2.6",
         "react-inspector": "^2.3.0",
         "uuid": "^3.3.2"
       }
     },
     "@storybook/addons": {
-      "version": "4.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-4.0.0-alpha.18.tgz",
-      "integrity": "sha512-eHK/up1cPj1rp/5mz/fKyXN69bgYaLyBMp1v3TPtiUeTmYuqbthGDIvDPaBsRqZPtyo/hXtLC4jy216OHTNQ7A==",
+      "version": "4.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-4.0.0-alpha.20.tgz",
+      "integrity": "sha512-FUNzh1G9Pxgfi6Ke+8I3Jk8xxNzkj9c6dDn/oI/nkg12R54FbSvutWdghN0lWS52c5VsWghoUIP0wozWhHhS7Q==",
       "dev": true,
       "requires": {
-        "@storybook/channels": "4.0.0-alpha.18",
-        "@storybook/components": "4.0.0-alpha.18",
+        "@storybook/channels": "4.0.0-alpha.20",
+        "@storybook/components": "4.0.0-alpha.20",
         "global": "^4.3.2",
         "util-deprecate": "^1.0.2"
       }
     },
     "@storybook/channel-postmessage": {
-      "version": "4.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-4.0.0-alpha.18.tgz",
-      "integrity": "sha512-OmDB1zorLvSRUzeBnPM+8JyxS2UalPt9NPNTxJFCH+ZKfvhO9A3DEethZgmKiGJ/r7RF2nEOl8r1TGpQ6iFx/g==",
+      "version": "4.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-4.0.0-alpha.20.tgz",
+      "integrity": "sha512-lPhXIsiJkp6ZGvPqx2b0uRvZcB0xnokSvRucHlqd1RKQkVttQ30a4tfKZyTYvsDsu5Di5TNCdIh6ekW6M/fB3w==",
       "dev": true,
       "requires": {
-        "@storybook/channels": "4.0.0-alpha.18",
+        "@storybook/channels": "4.0.0-alpha.20",
         "global": "^4.3.2",
         "json-stringify-safe": "^5.0.1"
       }
     },
     "@storybook/channels": {
-      "version": "4.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-4.0.0-alpha.18.tgz",
-      "integrity": "sha512-TPVbvXvuZhQgUxmgoZINlyZfSPFnc5nvOCNf4eww6gVJiqT5pDgPRLeImG+EVzkieowyCVLDC9NcgN0yRlEscA==",
+      "version": "4.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-4.0.0-alpha.20.tgz",
+      "integrity": "sha512-olmSGDoz7YO0Xs1u7eKgZNks+/2LBQMRNzmdfQN4Hgz5vjjhlp2Z68xWdTWiAWt0YxVmArhE/7OkehHgUyJp7g==",
       "dev": true
     },
     "@storybook/client-logger": {
-      "version": "4.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-4.0.0-alpha.18.tgz",
-      "integrity": "sha512-v+fvbYuZnF73XQvbD4h/hQbOgQ+sMcrqEFI65oqTI6RV3YBnckgMFqzcm+5B5Lc2RnhNXOvx5PUFCFWHcYQXGw==",
+      "version": "4.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-4.0.0-alpha.20.tgz",
+      "integrity": "sha512-ZOzThLBowJY+1r1wV6EenIf2XGzGXY3OTgTd6w4RHvaQwZS8kVrlxxRBjX91MT8fQtsxYz8pMUsTYGC7dELMEA==",
       "dev": true
     },
     "@storybook/components": {
-      "version": "4.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-4.0.0-alpha.18.tgz",
-      "integrity": "sha512-5FOomrDL/INrjy9a4wxILHm4/9zkX0EGlkdilwD1c6NjWVSXDD8+GqCfxDGb3RorXHaVJGcNV55te/fO3hEaWA==",
+      "version": "4.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-4.0.0-alpha.20.tgz",
+      "integrity": "sha512-U2reiKslmlwkCzp0lLuOGcv08gSpn+6lSLTfavDx+6K9wpbIn31o0pFZgJ/Zfgfr1xWGE1rExwx+ai4BbQUL1w==",
       "dev": true,
       "requires": {
-        "emotion": "^9.2.6",
-        "emotion-theming": "^9.2.6",
+        "@emotion/core": "0.13.0",
+        "@emotion/provider": "0.11.1",
+        "@emotion/styled": "0.10.5",
         "global": "^4.3.2",
         "lodash.pick": "^4.4.0",
         "lodash.throttle": "^4.1.1",
         "prop-types": "^15.6.2",
-        "react-emotion": "^9.2.6",
         "react-inspector": "^2.3.0",
         "react-split-pane": "^0.1.82",
         "react-textarea-autosize": "^7.0.4",
@@ -1067,24 +1140,27 @@
       }
     },
     "@storybook/core": {
-      "version": "4.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-4.0.0-alpha.18.tgz",
-      "integrity": "sha512-KMwHMAPW0XvdrEQbHtKerZFdoZZEjyo1ZDvtTpxmElj9qiEoUOAGTqzuY162x72VbwMHTY7yzmXAlAuohrW+9w==",
+      "version": "4.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-4.0.0-alpha.20.tgz",
+      "integrity": "sha512-e5sc9qAsSdxQ/jyLqpIUUwMfwvjHrgKKo06Cp5oEwhc2C0RcVPRZiaNaxHMNIe2lC5upV4B3f++ReKD6TZ51aw==",
       "dev": true,
       "requires": {
-        "@babel/plugin-proposal-class-properties": "^7.0.0-rc.3",
-        "@babel/plugin-transform-regenerator": "^7.0.0-rc.3",
-        "@babel/plugin-transform-runtime": "^7.0.0-rc.3",
-        "@babel/preset-env": "^7.0.0-rc.3",
-        "@babel/runtime": "^7.0.0-rc.3",
-        "@storybook/addons": "4.0.0-alpha.18",
-        "@storybook/channel-postmessage": "4.0.0-alpha.18",
-        "@storybook/client-logger": "4.0.0-alpha.18",
-        "@storybook/core-events": "4.0.0-alpha.18",
-        "@storybook/node-logger": "4.0.0-alpha.18",
-        "@storybook/ui": "4.0.0-alpha.18",
+        "@babel/plugin-proposal-class-properties": "^7.0.0",
+        "@babel/plugin-transform-regenerator": "^7.0.0",
+        "@babel/plugin-transform-runtime": "^7.0.0",
+        "@babel/preset-env": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "@emotion/core": "0.13.0",
+        "@emotion/provider": "0.11.1",
+        "@emotion/styled": "0.10.5",
+        "@storybook/addons": "4.0.0-alpha.20",
+        "@storybook/channel-postmessage": "4.0.0-alpha.20",
+        "@storybook/client-logger": "4.0.0-alpha.20",
+        "@storybook/core-events": "4.0.0-alpha.20",
+        "@storybook/node-logger": "4.0.0-alpha.20",
+        "@storybook/ui": "4.0.0-alpha.20",
         "airbnb-js-shims": "^2.1.0",
-        "autoprefixer": "^9.1.0",
+        "autoprefixer": "^9.1.3",
         "babel-plugin-macros": "^2.2.2",
         "babel-preset-minify": "^0.5.0-alpha.3cc09dcf",
         "case-sensitive-paths-webpack-plugin": "^2.1.2",
@@ -1094,30 +1170,30 @@
         "css-loader": "^1.0.0",
         "dotenv-webpack": "^1.5.7",
         "ejs": "^2.6.1",
-        "emotion": "^9.2.6",
         "express": "^4.16.3",
-        "file-loader": "^1.1.11",
+        "file-loader": "^2.0.0",
         "find-cache-dir": "^2.0.0",
         "generate-page-webpack-plugin": "^1.0.0",
         "global": "^4.3.2",
         "interpret": "^1.1.0",
-        "json5": "^1.0.1",
+        "json5": "^2.0.1",
         "postcss-flexbugs-fixes": "^4.1.0",
-        "postcss-loader": "^2.1.6",
+        "postcss-loader": "^3.0.0",
         "prop-types": "^15.6.2",
         "qs": "^6.5.2",
         "raw-loader": "^0.5.1",
         "react-dev-utils": "6.0.0-next.3e165448",
-        "react-emotion": "^9.2.6",
         "redux": "^4.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1",
         "serve-favicon": "^2.5.0",
         "shelljs": "^0.8.2",
-        "style-loader": "^0.21.0",
+        "style-loader": "^0.23.0",
         "svg-url-loader": "^2.3.2",
-        "universal-dotenv": "^1.8.2",
-        "url-loader": "^1.0.1",
-        "webpack": "^4.16.4",
-        "webpack-dev-middleware": "^3.1.3",
+        "universal-dotenv": "^1.9.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-dev-middleware": "^3.2.0",
         "webpack-hot-middleware": "^2.22.3"
       },
       "dependencies": {
@@ -1141,6 +1217,24 @@
             "js-tokens": "^3.0.0"
           }
         },
+        "ajv": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
+          "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+          "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
+          "dev": true
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -1148,18 +1242,24 @@
           "dev": true
         },
         "autoprefixer": {
-          "version": "9.1.3",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.1.3.tgz",
-          "integrity": "sha512-No9xrkPCGIHc9I52e+u1MuvkwfTOIXQt3tu+jGSONAJf4awvQmqOTWmk7JhA9Q3BTvBYIRdpS9PLFtrmpZcImg==",
+          "version": "9.1.5",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.1.5.tgz",
+          "integrity": "sha512-kk4Zb6RUc58ld7gdosERHMF3DzIYJc2fp5sX46qEsGXQQy5bXsu8qyLjoxuY1NuQ/cJuCYnx99BfjwnRggrYIw==",
           "dev": true,
           "requires": {
-            "browserslist": "^4.0.2",
-            "caniuse-lite": "^1.0.30000878",
+            "browserslist": "^4.1.0",
+            "caniuse-lite": "^1.0.30000884",
             "normalize-range": "^0.1.2",
             "num2fraction": "^1.2.2",
             "postcss": "^7.0.2",
             "postcss-value-parser": "^3.2.3"
           }
+        },
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+          "dev": true
         },
         "cross-spawn": {
           "version": "6.0.5",
@@ -1191,6 +1291,22 @@
           "requires": {
             "address": "^1.0.1",
             "debug": "^2.6.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "file-loader": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-2.0.0.tgz",
+          "integrity": "sha512-YCsBfd1ZGCyonOKLxPiKPdu+8ld9HAaMEvJewzz+b2eTF7uL5Zm/HdBF6FjCrpCMRq25Mi0U1gl4pwn2TlH7hQ==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "^1.0.2",
+            "schema-utils": "^1.0.0"
           }
         },
         "filesize": {
@@ -1271,10 +1387,16 @@
           "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
           "dev": true
         },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.0.1.tgz",
+          "integrity": "sha512-t6N/86QDIRYvOL259jR5c5TbtMnekl2Ib314mGeMh37zAwjgbWHieqijPH7pWaogmJq1F2I4Sphg19U1s+ZnXQ==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -1347,6 +1469,18 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.0"
+          }
+        },
+        "postcss-loader": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
+          "integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "^1.1.0",
+            "postcss": "^7.0.0",
+            "postcss-load-config": "^2.0.0",
+            "schema-utils": "^1.0.0"
           }
         },
         "qs": {
@@ -1422,6 +1556,17 @@
             "symbol-observable": "^1.2.0"
           }
         },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1436,13 +1581,35 @@
           "requires": {
             "ansi-regex": "^3.0.0"
           }
+        },
+        "style-loader": {
+          "version": "0.23.0",
+          "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.0.tgz",
+          "integrity": "sha512-uCcN7XWHkqwGVt7skpInW6IGO1tG6ReyFQ1Cseh0VcN6VdcFQi62aG/2F3Y9ueA8x4IVlfaSUxpmQXQD9QrEuQ==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "^1.1.0",
+            "schema-utils": "^0.4.5"
+          },
+          "dependencies": {
+            "schema-utils": {
+              "version": "0.4.7",
+              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+              "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+              "dev": true,
+              "requires": {
+                "ajv": "^6.1.0",
+                "ajv-keywords": "^3.1.0"
+              }
+            }
+          }
         }
       }
     },
     "@storybook/core-events": {
-      "version": "4.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-4.0.0-alpha.18.tgz",
-      "integrity": "sha512-0tUanxIjd4cR2FgCYR2vmL462+DAzwkwpV3ujRnyUHpbgCW/JOnwvy60Q5l4ZGF7fkQGQZkrU3CObrYBL4UB1w==",
+      "version": "4.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-4.0.0-alpha.20.tgz",
+      "integrity": "sha512-jftZG2tzo+uO8CGCu5FLodIpLx3wLde2OEjp1qiUasFFwfoyE1cKJDYf8gee3ijT+JTLXXxM0bRfprxLfSIn8Q==",
       "dev": true
     },
     "@storybook/mantra-core": {
@@ -1457,12 +1624,12 @@
       }
     },
     "@storybook/node-logger": {
-      "version": "4.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-4.0.0-alpha.18.tgz",
-      "integrity": "sha512-vEU4LOG9w/3QXv/eMn1+EkX2MPUyiUD8vTKqDbNo4kYBmAl0tBPHGJJ/A6Zr4cjsZa/7jI506ZONt5JKVDtyWQ==",
+      "version": "4.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-4.0.0-alpha.20.tgz",
+      "integrity": "sha512-aAC/qrAnnFII+co6JEq7SNe3Po9WpjQKWNX7ESsTUX3f9e19wFCqtX0BVEKKda0hNX4fbbMbC+tZ9SG3feBUpg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.0.0-rc.3",
+        "@babel/runtime": "^7.0.0",
         "npmlog": "^4.1.2"
       }
     },
@@ -1485,23 +1652,23 @@
       }
     },
     "@storybook/react": {
-      "version": "4.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-4.0.0-alpha.18.tgz",
-      "integrity": "sha512-SBjDmEAQYsNuZqqSpezb8qfO+9CYpgiIL1FdaD3/lvxvc1ipnQd1POo3mi8veC/fraByCoYD1y3baUzWQtxN9Q==",
+      "version": "4.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-4.0.0-alpha.20.tgz",
+      "integrity": "sha512-j7UAfns1zJA1aOBmz3WjZ7VTujXzOXsziTyiV9lytJJ+S7NX2yJJk+EH5bx7OYGOHtBhAEEJt70Pq56y49roNQ==",
       "dev": true,
       "requires": {
-        "@babel/preset-flow": "^7.0.0-rc.3",
-        "@babel/preset-react": "^7.0.0-rc.3",
-        "@babel/runtime": "^7.0.0-rc.3",
-        "@storybook/core": "4.0.0-alpha.18",
+        "@babel/preset-flow": "^7.0.0",
+        "@babel/preset-react": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "@emotion/styled": "0.10.5",
+        "@storybook/core": "4.0.0-alpha.20",
         "babel-plugin-react-docgen": "^2.0.0-babel7.0",
         "common-tags": "^1.8.0",
         "emotion": "^9.2.6",
         "global": "^4.3.2",
         "lodash.flattendeep": "^4.4.0",
         "prop-types": "^15.6.2",
-        "react-dev-utils": "6.0.0-next.3e165448",
-        "react-emotion": "^9.2.6"
+        "react-dev-utils": "6.0.0-next.3e165448"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -1746,20 +1913,22 @@
       }
     },
     "@storybook/ui": {
-      "version": "4.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-4.0.0-alpha.18.tgz",
-      "integrity": "sha512-vmkm/Kfsotek9/6ewu2EY69bhy7oAMCo11pzIQVkwv6LvJRM3aoq1bTb2mMkPmcnsKHkmIh26+ptKZKCnMVkjQ==",
+      "version": "4.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-4.0.0-alpha.20.tgz",
+      "integrity": "sha512-TZS6OUcL/bN2Cu0Y7Z99XmPceRCNA0Xk7FAGyq1SInOrVtca8iI5Rjs4kpqdTmzvmGvB1x07D/tllnpZhdl9tg==",
       "dev": true,
       "requires": {
-        "@ndelangen/react-treebeard": "^2.1.0",
-        "@storybook/components": "4.0.0-alpha.18",
-        "@storybook/core-events": "4.0.0-alpha.18",
+        "@emotion/core": "0.13.0",
+        "@emotion/provider": "0.11.1",
+        "@emotion/styled": "0.10.5",
+        "@ndelangen/react-treebeard": "^3.0.0",
+        "@storybook/components": "4.0.0-alpha.20",
+        "@storybook/core-events": "4.0.0-alpha.20",
         "@storybook/mantra-core": "^1.7.2",
         "@storybook/podda": "^1.2.3",
         "@storybook/react-komposer": "^2.0.4",
         "deep-equal": "^1.0.1",
-        "emotion": "^9.2.6",
-        "emotion-theming": "^9.2.6",
+        "emotion": "^9.2.8",
         "events": "^3.0.0",
         "fuse.js": "^3.2.1",
         "global": "^4.3.2",
@@ -1770,7 +1939,6 @@
         "lodash.throttle": "^4.1.1",
         "prop-types": "^15.6.2",
         "qs": "^6.5.2",
-        "react-emotion": "^9.2.6",
         "react-fuzzy": "^0.5.2",
         "react-lifecycles-compat": "^3.0.4",
         "react-modal": "^3.5.1"
@@ -1850,9 +2018,9 @@
       "integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY="
     },
     "@types/node": {
-      "version": "7.0.69",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.69.tgz",
-      "integrity": "sha512-S5NC8HV6HnRipg8nC0j30TPl7ktXjRTKqgyINLNe8K/64UJUI8Lq0sRopXC0hProsV2F5ibj8IqPkl1xpGggrw=="
+      "version": "7.0.70",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.70.tgz",
+      "integrity": "sha512-bAcW/1aM8/s5iFKhRpu/YJiQf/b1ZwnMRqqsWRCmAqEDQF2zY8Ez3Iu9AcZKFKc3vCJc8KJVpJ6Pn54sJ1BvXQ=="
     },
     "@types/prop-types": {
       "version": "15.5.5",
@@ -2119,9 +2287,9 @@
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "airbnb-js-shims": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-2.1.0.tgz",
-      "integrity": "sha512-FMhKEeAJ07nc/8Q5xiT1lA0XFiDWkPJ6wDZ73mnRCCJItVwgaeqO+wu3d5KyaPHWLaarZwbNkFfgcz35BkjonA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-2.1.1.tgz",
+      "integrity": "sha512-h8UtyB/TCdOwWoEPQJGHgsWwSnTqPrRZbhyZYjAwY9/AbjdjfkKy9L/T3fIFS6MKX8YrpWFRm6xqFSgU+2DRGw==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -2162,38 +2330,10 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
     },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "alphanum-sort": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -2550,7 +2690,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -3107,43 +3247,41 @@
       }
     },
     "babel-plugin-remove-graphql-queries": {
-      "version": "2.0.2-rc.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.0.2-rc.2.tgz",
-      "integrity": "sha512-2LdMkL4NEk1HCe7d6Zx81KT7C4oi993gTHmIfmvANJvRUAoSMiVt1xgFyRyjsdQ8yHYLR+X1BoHAkXCsrJsaTA=="
+      "version": "2.0.2-rc.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.0.2-rc.3.tgz",
+      "integrity": "sha512-dim5ayTKQZYa/j1NHPNx8M0cR6ejycZ10SZcqc97al9JFoG5CQoJAAwBk8y5Ix5YQUceZl34q5+qTfzm+AlkVg=="
     },
     "babel-plugin-styled-components": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.5.1.tgz",
-      "integrity": "sha1-MdvraW0TVNFYXmDWbHkF9eR0r80=",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.6.3.tgz",
+      "integrity": "sha512-/SBNhpMmomki33L4SotfzwRSz57ao3FsBxTALEcgXXLU/B8UzI6Pn2xJzdLNSPprHfnlHyhiaslR0okDPzW5RQ==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0-beta.37",
-        "babel-types": "^6.26.0",
-        "stylis": "^3.0.0"
+        "lodash": "^4.17.10"
       }
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
       "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
     },
     "babel-plugin-syntax-dynamic-import": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
       "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
     },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
       "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -3450,6 +3588,11 @@
         "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        },
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
@@ -3571,6 +3714,12 @@
           "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
           "dev": true
         },
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+          "dev": true
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -3589,6 +3738,13 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        }
       }
     },
     "babel-template": {
@@ -3666,7 +3822,7 @@
     },
     "babylon": {
       "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
       "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
     },
     "backo2": {
@@ -3782,9 +3938,9 @@
       }
     },
     "better-queue-memory": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/better-queue-memory/-/better-queue-memory-1.0.2.tgz",
-      "integrity": "sha1-qm0WmqHQzHdAkYXLnLXH3CUbzUE="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/better-queue-memory/-/better-queue-memory-1.0.3.tgz",
+      "integrity": "sha512-QLFkfV+k/7e4L4FR7kqkXKtRi22kl68c/3AaBs0ArDSz0iiuAl0DjVlb6gM220jW7izLE5TRy7oXOd4Cxa0wog=="
     },
     "big.js": {
       "version": "3.2.0",
@@ -3811,9 +3967,9 @@
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
     },
     "bn.js": {
       "version": "4.11.8",
@@ -4009,12 +4165,12 @@
       }
     },
     "browserslist": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.0.tgz",
-      "integrity": "sha512-kQBKB8hnq1SRfSpwHDpM1JNHAyk9fydW8hIDvndR2ijTFKIlBPEvkJkCt8JznOugdm12/YCaRgyq/sqDGz9PwA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.1.tgz",
+      "integrity": "sha512-VBorw+tgpOtZ1BYhrVSVTzTt/3+vSE3eFUh0N2GCFK1HffceOaf32YS/bs6WiFhjDAblAFrx85jMy3BG9fBK2Q==",
       "requires": {
-        "caniuse-lite": "^1.0.30000878",
-        "electron-to-chromium": "^1.3.61",
+        "caniuse-lite": "^1.0.30000884",
+        "electron-to-chromium": "^1.3.62",
         "node-releases": "^1.0.0-alpha.11"
       }
     },
@@ -4156,22 +4312,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
-    "camelcase-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-        }
-      }
-    },
     "caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -4184,14 +4324,14 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000883",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000883.tgz",
-      "integrity": "sha512-ovvb0uya4cKJct8Rj9Olstz0LaWmyJhCp3NawRG5fVigka8pEhIIwipF7zyYd2Q58UZb5YfIt52pVF444uj2kQ=="
+      "version": "1.0.30000885",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000885.tgz",
+      "integrity": "sha512-cXKbYwpxBLd7qHyej16JazPoUacqoVuDhvR61U7Fr5vSxMUiodzcYa1rQYRYfZ5GexV03vGZHd722vNPLjPJGQ=="
     },
     "capture-stack-trace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.1.2",
@@ -4208,17 +4348,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
       "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw=="
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      }
     },
     "chalk": {
       "version": "2.4.1",
@@ -4304,6 +4433,14 @@
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.2"
           }
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "requires": {
+            "@types/node": "*"
+          }
         }
       }
     },
@@ -4358,6 +4495,16 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+    },
+    "cjk-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cjk-regex/-/cjk-regex-2.0.0.tgz",
+      "integrity": "sha512-E4gFi2f3jC0zFVHpaAcupW+gv9OejZ2aV3DP/LlSO0dDcZJAXw7W0ivn+vN17edN/PhU4HCgs1bfx7lPK7FpdA==",
+      "dev": true,
+      "requires": {
+        "regexp-util": "^1.2.1",
+        "unicode-regex": "^2.0.0"
+      }
     },
     "class-utils": {
       "version": "0.3.6",
@@ -4650,9 +4797,12 @@
       "integrity": "sha1-Gb+yyRYvnhHC8Ewsed4rfoCVxic="
     },
     "convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
     },
     "cookie": {
       "version": "0.3.1",
@@ -4698,7 +4848,8 @@
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4745,15 +4896,6 @@
           "integrity": "sha512-yS+t7l5FeYeiIyADyqjFBJvdotpphHb2S3mP4qak5BpV7ODvxuyAVF24IchEslW+A1MWHAhn5SiOW6GZIumiEQ==",
           "dev": true
         }
-      }
-    },
-    "create-emotion-styled": {
-      "version": "9.2.8",
-      "resolved": "https://registry.npmjs.org/create-emotion-styled/-/create-emotion-styled-9.2.8.tgz",
-      "integrity": "sha512-2LrNM5MREWzI5hZK+LyiBHglwE18WE3AEbBQgpHQ1+zmyLSm/dJsUZBeFAwuIMb+TjNZP0KsMZlV776ufOtFdg==",
-      "dev": true,
-      "requires": {
-        "@emotion/is-prop-valid": "^0.6.1"
       }
     },
     "create-error-class": {
@@ -4820,7 +4962,7 @@
       "dependencies": {
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
         }
       }
@@ -5362,9 +5504,9 @@
       "dev": true
     },
     "detect-node": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
-      "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "detect-port": {
       "version": "1.2.3",
@@ -5521,14 +5663,6 @@
         }
       }
     },
-    "dom-urls": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
-      "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
-      "requires": {
-        "urijs": "^1.16.1"
-      }
-    },
     "dom-walk": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
@@ -5665,9 +5799,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.62",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.62.tgz",
-      "integrity": "sha512-x09ndL/Gjnuk3unlAyoGyUg3wbs4w/bXurgL7wL913vXHAOWmMhrLf1VNGRaMLngmadd5Q8gsV9BFuIr6rP+Xg=="
+      "version": "1.3.63",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.63.tgz",
+      "integrity": "sha512-Ec35NNY040HKuSxMAzBMgz/uUI78amSWpBUD9x2gN7R7gkb/wgAcClngWklcLP0/lm/g0UUYHnC/tUIlZj8UvQ=="
     },
     "elliptic": {
       "version": "6.4.1",
@@ -5701,15 +5835,6 @@
       "requires": {
         "babel-plugin-emotion": "^9.2.8",
         "create-emotion": "^9.2.6"
-      }
-    },
-    "emotion-theming": {
-      "version": "9.2.6",
-      "resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-9.2.6.tgz",
-      "integrity": "sha512-sbZStubPmaDuMhs3+saH4XegnoMgbVtEY2giD1MP+maDinCnJdzf/1Apcip1wo5HMAN7vrjvpmcY13pH34xR6g==",
-      "dev": true,
-      "requires": {
-        "hoist-non-react-statics": "^2.3.1"
       }
     },
     "encodeurl": {
@@ -5848,15 +5973,10 @@
       }
     },
     "es5-shim": {
-      "version": "4.5.10",
-      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.10.tgz",
-      "integrity": "sha512-vmryBdqKRO8Ei9LJ4yyEk/EOmAOGIagcHDYPpTAi6pot4IMHS1AC2q5cTKPmydpijg2iX8DVmCuqgrNxIWj8Yg==",
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.11.tgz",
+      "integrity": "sha512-7NY8JWNUZGpg+Ade2/ufJ9N6uMCiII5Oyf1H89/AuJKjYqUBU7i5bSnz0rOcIjNzQkvPJ+TfP19BTDP2FJg9pg==",
       "dev": true
-    },
-    "es6-promise": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
     },
     "es6-shim": {
       "version": "0.35.3",
@@ -6828,7 +6948,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -7393,9 +7513,9 @@
       "dev": true
     },
     "gatsby": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.0.0-rc.4.tgz",
-      "integrity": "sha512-77eR41SgOfmdLv6LsM3mCoTrVM/C8HBQ5BR37LSenQfb6xb/AvAeQhaBGJ7Tpl7eUZGCaDMC4p7f7NmyC0PAQQ==",
+      "version": "2.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.0.0-rc.13.tgz",
+      "integrity": "sha512-mRBSMuR7oQkwAkqXMuHIAVg4aXWj/oRZPF3vtCuc7fwAF0i96hqmBavRFi4eiPvbdyLdBm6JQuNoNCjKL25aiQ==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/core": "^7.0.0",
@@ -7416,7 +7536,7 @@
         "babel-plugin-add-module-exports": "^0.2.1",
         "babel-plugin-dynamic-import-node": "^1.2.0",
         "babel-plugin-macros": "^2.4.0",
-        "babel-plugin-remove-graphql-queries": "^2.0.2-rc.2",
+        "babel-plugin-remove-graphql-queries": "^2.0.2-rc.3",
         "better-queue": "^3.8.6",
         "bluebird": "^3.5.0",
         "chalk": "^2.3.2",
@@ -7452,11 +7572,11 @@
         "gatsby-cli": "^2.0.0-rc.1",
         "gatsby-link": "^2.0.0-rc.2",
         "gatsby-plugin-page-creator": "^2.0.0-rc.1",
-        "gatsby-react-router-scroll": "^2.0.0-rc.1",
+        "gatsby-react-router-scroll": "^2.0.0-rc.2",
         "glob": "^7.1.1",
         "graphql": "^0.13.2",
         "graphql-relay": "^0.5.5",
-        "graphql-skip-limit": "^2.0.0-rc.2",
+        "graphql-skip-limit": "^2.0.0-rc.3",
         "graphql-tools": "^3.0.4",
         "graphql-type-json": "^0.2.1",
         "hash-mod": "^0.0.5",
@@ -7513,6 +7633,11 @@
         "yaml-loader": "^0.5.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        },
         "gatsby-cli": {
           "version": "2.0.0-rc.1",
           "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.0.0-rc.1.tgz",
@@ -7612,7 +7737,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -7628,15 +7753,14 @@
       }
     },
     "gatsby-plugin-offline": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-offline/-/gatsby-plugin-offline-2.0.0-rc.1.tgz",
-      "integrity": "sha512-fMUYdWaiYnWNagoT3CB/a7Q844L7NIScYLLwH9fN2n51XuheMv7XnNjzOo5bVD7xZQc9PwZHwgUbr/egtWja1Q==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-offline/-/gatsby-plugin-offline-2.0.0-rc.4.tgz",
+      "integrity": "sha512-B4CyASltYazNL1WXMnnSbuQO0U/I4HJPnjoj/Mm1HsFabEEDCXg66tc6SOEGU/dfujLffv/c+tHdFRdjS6XljA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "cheerio": "^1.0.0-rc.2",
         "lodash": "^4.17.10",
-        "replace-in-file": "^3.4.2",
-        "sw-precache": "^5.2.1"
+        "workbox-build": "^3.4.1"
       }
     },
     "gatsby-plugin-page-creator": {
@@ -7786,9 +7910,9 @@
       }
     },
     "gatsby-react-router-scroll": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.0.0-rc.1.tgz",
-      "integrity": "sha512-SpVj+zvNzhFIPPVfE0LqnZnXblKxh9knVIyO5APL3DKji7L6kipd6PhaCgoy1ilrJ7ivRzIqCrz/Xg0kBl9JHQ==",
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.0.0-rc.2.tgz",
+      "integrity": "sha512-Pj/i0q+6d2IN0UV6NpKj7eDm/83bPucEg4wwdR4XKkvlF48ViL7D4iFx/H5svF5gezRPjgCF1AwHDJEdwRKh2Q==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "scroll-behavior": "^0.9.9",
@@ -7847,9 +7971,10 @@
       "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
     },
     "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+      "dev": true
     },
     "get-stream": {
       "version": "3.0.0",
@@ -8086,9 +8211,9 @@
       }
     },
     "graphql-skip-limit": {
-      "version": "2.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/graphql-skip-limit/-/graphql-skip-limit-2.0.0-rc.2.tgz",
-      "integrity": "sha512-lfsvkOTsGiyTrvsGTwgTS12dgfaqo4BvhQu4IkpLU1Cs/sXypiWg1unPF1zfLLX2krVjKCsT4SYw5eZZbDxu6w==",
+      "version": "2.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/graphql-skip-limit/-/graphql-skip-limit-2.0.0-rc.3.tgz",
+      "integrity": "sha512-Z3NWLSkvTzUsX18OUJQ5/W/FW00X1wUZU9kZTGsmlgjs7UROQMha5Q9HAO7mDkxJp9ahKyz5f6hCDgT1EvmZgQ==",
       "requires": {
         "@babel/runtime": "^7.0.0"
       }
@@ -8140,84 +8265,41 @@
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
     },
     "handlebars": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
+      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
       "dev": true,
       "requires": {
-        "async": "^1.4.0",
+        "async": "^2.5.0",
         "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
-          "optional": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
-          "optional": true,
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
+            "lodash": "^4.17.10"
           }
         },
         "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         },
         "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "version": "3.4.9",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+          "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
-          "optional": true
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
-            "window-size": "0.1.0"
+            "commander": "~2.17.1",
+            "source-map": "~0.6.1"
           }
         }
       }
@@ -8524,7 +8606,7 @@
         },
         "os-locale": {
           "version": "1.4.0",
-          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
             "lcid": "^1.0.0"
@@ -8563,7 +8645,7 @@
         },
         "react": {
           "version": "15.4.2",
-          "resolved": "http://registry.npmjs.org/react/-/react-15.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/react/-/react-15.4.2.tgz",
           "integrity": "sha1-QfeZGyYYU5K6m66WyIiefgGDl+8=",
           "requires": {
             "fbjs": "^0.8.4",
@@ -8617,11 +8699,6 @@
           "requires": {
             "is-utf8": "^0.2.0"
           }
-        },
-        "window-size": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
         },
         "yargs": {
           "version": "4.6.0",
@@ -8693,7 +8770,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
       "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
       "requires": {
         "http-proxy": "^1.16.2",
@@ -8758,12 +8835,6 @@
           "requires": {
             "locate-path": "^3.0.0"
           }
-        },
-        "get-stdin": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-          "dev": true
         },
         "locate-path": {
           "version": "3.0.0",
@@ -8903,26 +8974,66 @@
       "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
     },
     "import-local": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-      "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+      "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
       "requires": {
-        "pkg-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0",
         "resolve-cwd": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        }
       }
     },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-    },
-    "indent-string": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "requires": {
-        "repeating": "^2.0.0"
-      }
     },
     "indexes-of": {
       "version": "1.0.1",
@@ -9572,11 +9683,6 @@
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.2"
           }
-        },
-        "parse5": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-          "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
         }
       }
     },
@@ -9697,13 +9803,6 @@
       "requires": {
         "package-json": "^4.0.0"
       }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
-      "optional": true
     },
     "lcid": {
       "version": "1.0.0",
@@ -9871,11 +9970,6 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
-    "lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
-    },
     "lodash.every": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.every/-/lodash.every-4.6.0.tgz",
@@ -10019,12 +10113,6 @@
       "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
       "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
     },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
-    },
     "longest-streak": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.2.tgz",
@@ -10075,9 +10163,9 @@
       }
     },
     "make-error": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
-      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
       "dev": true
     },
     "mamacro": {
@@ -10085,15 +10173,18 @@
       "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
       "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA=="
     },
+    "map-age-cleaner": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz",
+      "integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
-    },
-    "map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
     "map-visit": {
       "version": "1.0.0",
@@ -10225,6 +10316,11 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "memoize-one": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.2.tgz",
+      "integrity": "sha512-ucx2DmXTeZTsS4GPPUZCbULAN7kdPT1G+H49Y34JjbQ5ESc6OGhVxKvb1iKhr9v19ZB9OtnHwNnhUnNR/7Wteg=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -10232,109 +10328,6 @@
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
-      }
-    },
-    "meow": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        }
       }
     },
     "merge-descriptors": {
@@ -10563,7 +10556,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -10840,9 +10833,9 @@
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
     "normalize-url": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.2.0.tgz",
-      "integrity": "sha512-WvF3Myk0NhXkG8S9bygFM4IC1KOvnVJGq0QoGeoqOYOBeinBZp5ybW3QuYbTc89lkWBMM9ZBO4QGRoc0353kKA=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -11145,10 +11138,20 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
     },
     "p-limit": {
       "version": "1.3.0",
@@ -11288,12 +11291,9 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
     },
     "parse5": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-      "requires": {
-        "@types/node": "*"
-      }
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
     },
     "parseqs": {
       "version": "0.0.5",
@@ -11654,7 +11654,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -12089,7 +12089,7 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
-      "version": "git+https://github.com/prettier/prettier.git#50c9115632e8b90088e514bc63090e07e9b49b4e",
+      "version": "git+https://github.com/prettier/prettier.git#87376f93f35f49f8dc52b41da82348d11c2ea638",
       "from": "git+https://github.com/prettier/prettier.git#master",
       "dev": true,
       "requires": {
@@ -12133,6 +12133,7 @@
         "postcss-selector-parser": "2.2.3",
         "postcss-values-parser": "1.5.0",
         "regexp-util": "1.2.2",
+        "remark-math": "1.0.4",
         "remark-parse": "5.0.0",
         "resolve": "1.5.0",
         "semver": "5.4.1",
@@ -12183,16 +12184,6 @@
             "supports-color": "^4.0.0"
           }
         },
-        "cjk-regex": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/cjk-regex/-/cjk-regex-2.0.0.tgz",
-          "integrity": "sha512-E4gFi2f3jC0zFVHpaAcupW+gv9OejZ2aV3DP/LlSO0dDcZJAXw7W0ivn+vN17edN/PhU4HCgs1bfx7lPK7FpdA==",
-          "dev": true,
-          "requires": {
-            "regexp-util": "^1.2.1",
-            "unicode-regex": "^2.0.0"
-          }
-        },
         "has-flag": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
@@ -12213,7 +12204,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -12222,6 +12213,15 @@
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
           "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
           "dev": true
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
         },
         "resolve": {
           "version": "1.5.0",
@@ -12247,29 +12247,19 @@
             "has-flag": "^2.0.0"
           }
         },
-        "unicode-regex": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/unicode-regex/-/unicode-regex-2.0.0.tgz",
-          "integrity": "sha512-5nbEG2YU7loyTvPABaKb+8B0u8L7vWCsVmCSsiaO249ZdMKlvrXlxR2ex4TUVAdzv/Cne/TdoXSSaJArGXaleQ==",
+        "unified": {
+          "version": "6.1.6",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-6.1.6.tgz",
+          "integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
           "dev": true,
           "requires": {
-            "regexp-util": "^1.2.0"
-          }
-        },
-        "yaml": {
-          "version": "1.0.0-rc.8",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.0.0-rc.8.tgz",
-          "integrity": "sha512-+6a1nAiwS141AYKYsGXp9A7uLsYwY5f2ql9BhpewjfLm8u8HYh43ZD+8GWY4FNusZjU5+oa9cg9Spx0orQSf1g==",
-          "dev": true
-        },
-        "yaml-unist-parser": {
-          "version": "1.0.0-rc.4",
-          "resolved": "https://registry.npmjs.org/yaml-unist-parser/-/yaml-unist-parser-1.0.0-rc.4.tgz",
-          "integrity": "sha512-y09JF17+/tMqr5fF5vP9hQsDy434LTNtpoBPj8pNssnGAnB1susUtTFkM8Cum0N0Gb8yqzp8TorKwrPMEFLP9Q==",
-          "dev": true,
-          "requires": {
-            "lines-and-columns": "^1.1.6",
-            "tslib": "^1.9.1"
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "trough": "^1.0.0",
+            "vfile": "^2.0.0",
+            "x-is-function": "^1.0.4",
+            "x-is-string": "^0.1.0"
           }
         }
       }
@@ -12541,14 +12531,14 @@
       }
     },
     "react": {
-      "version": "16.4.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.4.2.tgz",
-      "integrity": "sha512-dMv7YrbxO4y2aqnvA7f/ik9ibeLSHQJTI6TrYAenPSaQ6OXfb+Oti+oJiy8WBxgRzlKatYqtCjphTgDSCEiWFg==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.5.0.tgz",
+      "integrity": "sha512-nw/yB/L51kA9PsAy17T1JrzzGRk+BlFCJwFF7p+pwVxgqwPjYNeZEkkH7LXn9dmflolrYMXLWMTkQ77suKPTNQ==",
       "requires": {
-        "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.2",
+        "schedule": "^0.3.0"
       }
     },
     "react-dev-utils": {
@@ -12583,7 +12573,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -12658,24 +12648,14 @@
       }
     },
     "react-dom": {
-      "version": "16.4.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.2.tgz",
-      "integrity": "sha512-Usl73nQqzvmJN+89r97zmeUpQDKDlh58eX6Hbs/ERdDHzeBzWy+ENk7fsGQ+5KxArV1iOFPT46/VneklK9zoWw==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.5.0.tgz",
+      "integrity": "sha512-qgsQdjFH54pQ1AGLCBKsqjPxib4Pnp+cOsNxGPlkHn5YnsSt43sBvHSif6FheY7NMMS6HPeSJOxXf6ECanjacA==",
       "requires": {
-        "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
-      }
-    },
-    "react-emotion": {
-      "version": "9.2.8",
-      "resolved": "https://registry.npmjs.org/react-emotion/-/react-emotion-9.2.8.tgz",
-      "integrity": "sha512-wBtVqGLQR49QG8hl5KDxIMBZtRR6W7n39bk9tq+YU1bfh0RmfLfr5Uatz5NDg86A+XDVX5jFhtXaKxHuKQDCaw==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-emotion": "^9.2.8",
-        "create-emotion-styled": "^9.2.8"
+        "prop-types": "^15.6.2",
+        "schedule": "^0.3.0"
       }
     },
     "react-error-overlay": {
@@ -12707,9 +12687,9 @@
       }
     },
     "react-hot-loader": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.3.5.tgz",
-      "integrity": "sha512-6kKabumYl0rYaG9ynZMb7Wq+aR8BO9cctveYuDZJIjwXrfsABrkRGvN3QiQfUL42dh8GllkxhRFXOty+vr4aSA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.3.6.tgz",
+      "integrity": "sha512-iuBeBkLz7tdkKmKduNww9o5JY4ZH1XI0TWwkWToHIqfOSh1xMCqLMSYXUasWfgZWykWWa9IkueYab+cDq2jyWg==",
       "requires": {
         "fast-levenshtein": "^2.0.6",
         "global": "^4.3.0",
@@ -12730,9 +12710,9 @@
       }
     },
     "react-is": {
-      "version": "16.4.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.2.tgz",
-      "integrity": "sha512-rI3cGFj/obHbBz156PvErrS5xc6f1eWyTwyV4mo0vF2lGgXgS+mm7EKD5buLJq6jNgIagQescGSVG2YzgXt8Yg=="
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.5.0.tgz",
+      "integrity": "sha512-kpkCGLsChXTEQJVmowQqHpCjHKJFwB4SIChYaaaiAkq8OtE2aBg5pQe8/xnFlGmz9KmMx1H4oQRUyxP7qC9v5A=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -12773,9 +12753,9 @@
       }
     },
     "react-style-proptype": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.2.1.tgz",
-      "integrity": "sha512-Z02QsgmdZ4wYNxJsHhNGGZsIF8+MO93fYmdPaC+ljdqX3rq8tl/fSMXOGBbofGJNzq5W/2LFcONllmV6vzyYHA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.2.2.tgz",
+      "integrity": "sha512-ywYLSjNkxKHiZOqNlso9PZByNEY+FTyh3C+7uuziK0xFXu9xzdyfHwg4S9iyiRRoPCR4k2LqaBBsWVmSBwCWYQ==",
       "dev": true,
       "requires": {
         "prop-types": "^15.5.4"
@@ -12899,15 +12879,6 @@
             "brace-expansion": "^1.0.0"
           }
         }
-      }
-    },
-    "redent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
       }
     },
     "reduce-css-calc": {
@@ -13076,7 +13047,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -13168,6 +13139,15 @@
         "remark-parse": "^5.0.0",
         "remark-stringify": "^5.0.0",
         "unified": "^6.0.0"
+      }
+    },
+    "remark-math": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-1.0.4.tgz",
+      "integrity": "sha512-aVyne6nKnlZPmCg+dmalKcUS1y+s3diWhKduV7l7sPqSeGHsncJatu/1P1U73zsNNjQZFyEJ2T4ArpjqOaEpFw==",
+      "dev": true,
+      "requires": {
+        "trim-trailing-lines": "^1.1.0"
       }
     },
     "remark-parse": {
@@ -13284,91 +13264,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
-    },
-    "replace-in-file": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-3.4.2.tgz",
-      "integrity": "sha512-wb2EU5MBBqUty+b1xSIqa0IKs5M2/a+4Ldw8KM5Gpe1btv16K0eii6nMxyNhAmRZhCEPrge0ss5Ij9f7vJEYcw==",
-      "requires": {
-        "chalk": "^2.4.1",
-        "glob": "^7.1.2",
-        "yargs": "^12.0.1"
-      },
-      "dependencies": {
-        "decamelize": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
-          "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
-          "requires": {
-            "xregexp": "4.0.0"
-          }
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
-        },
-        "yargs": {
-          "version": "12.0.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
-          "integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
-          "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^2.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^10.1.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
-          "requires": {
-            "camelcase": "^4.1.0"
-          }
-        }
-      }
     },
     "request": {
       "version": "2.88.0",
@@ -13531,16 +13426,6 @@
       "resolved": "https://registry.npmjs.org/ric/-/ric-1.3.0.tgz",
       "integrity": "sha1-jpUEJgnOghNUioMWTQjpT66UkJ8="
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.1"
-      }
-    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -13594,9 +13479,9 @@
       }
     },
     "rxjs": {
-      "version": "5.5.11",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
-      "integrity": "sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
       "dev": true,
       "requires": {
         "symbol-observable": "1.0.1"
@@ -13632,6 +13517,14 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "schedule": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/schedule/-/schedule-0.3.0.tgz",
+      "integrity": "sha512-20+1KVo517sR7Nt+bYBN8a+bEJDKLPEx7Ohtts1kX05E4/HY53YUNuhfkVNItmWAnBYHcpG9vsd2/CJxG+aPCQ==",
+      "requires": {
+        "object-assign": "^4.1.1"
+      }
     },
     "schema-utils": {
       "version": "0.4.7",
@@ -13832,11 +13725,6 @@
         "send": "0.16.2"
       }
     },
-    "serviceworker-cache-polyfill": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
-      "integrity": "sha1-3hnuc77yGrPAdAo3sz22JGS6ves="
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -13898,14 +13786,14 @@
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "sharp": {
-      "version": "0.20.7",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.20.7.tgz",
-      "integrity": "sha512-DB0n+Lnhz5n3nLAZgN1zRQ8E+lsz+zKOt1FT9F6l5QkJn3fy/fm+SCvZmHlQ68cratWhyG2TbeFKwopHtHwCtg==",
+      "version": "0.20.8",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.20.8.tgz",
+      "integrity": "sha512-A8NaPGWRDKpmHTi8sl2xzozYXhTQWBb/GaJ8ZPU7L/vKW8wVvd4Yq+isJ0c7p9sX5gnjPQcM3eOfHuvvnZ2fOQ==",
       "requires": {
         "color": "^3.0.0",
         "detect-libc": "^1.0.3",
         "fs-copy-file-sync": "^1.1.1",
-        "nan": "^2.10.0",
+        "nan": "^2.11.0",
         "npmlog": "^4.1.2",
         "prebuild-install": "^4.0.0",
         "semver": "^5.5.1",
@@ -14562,14 +14450,6 @@
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
-    "strip-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "requires": {
-        "get-stdin": "^4.0.1"
-      }
-    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -14590,41 +14470,26 @@
       }
     },
     "styled-components": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.5.tgz",
-      "integrity": "sha512-/4c4/72+QAZ8LO+VIzTcitdjMcJleOln1laK9HZr166O+OmGpKZYt3+hRn0YhYPytwDGfx9J5c7WhU7Oys+nSw==",
+      "version": "4.0.0-beta.0-2",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.0.0-beta.0-2.tgz",
+      "integrity": "sha512-R0aOZzJuERs1dDdYsyzpQ9F4S5bGGClE2Ck09txnJJNTZrnRn7PfGQx5eBRFn+WCi8shNf9S70DlW1G9loWAHQ==",
       "requires": {
-        "buffer": "^5.0.3",
+        "@emotion/is-prop-valid": "^0.6.5",
         "css-to-react-native": "^2.0.3",
-        "fbjs": "^0.8.16",
-        "hoist-non-react-statics": "^2.5.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "memoize-one": "^4.0.0",
         "prop-types": "^15.5.4",
         "react-is": "^16.3.1",
         "stylis": "^3.5.0",
-        "stylis-rule-sheet": "^0.0.10",
-        "supports-color": "^3.2.3"
+        "stylis-rule-sheet": "^0.0.10"
       },
       "dependencies": {
-        "buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.0.tgz",
-          "integrity": "sha512-nUJyfChH7PMJy75eRDCCKtszSEFokUNXC1hNVSe+o+VdcgvDPLs20k3v8UXI8ruRYAJiYtyRea8mYyqPxoHWDw==",
+        "hoist-non-react-statics": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.0.1.tgz",
+          "integrity": "sha512-1kXwPsOi0OGQIZNVMPvgWJ9tSnGMiMfJdihqEzrPEXlHOBh9AAHXX/QYmAJTXztnz/K+PQ8ryCb4eGaN6HlGbQ==",
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "requires": {
-            "has-flag": "^1.0.0"
+            "react-is": "^16.3.2"
           }
         }
       }
@@ -14707,47 +14572,6 @@
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
-          }
-        }
-      }
-    },
-    "sw-precache": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/sw-precache/-/sw-precache-5.2.1.tgz",
-      "integrity": "sha512-8FAy+BP/FXE+ILfiVTt+GQJ6UEf4CVHD9OfhzH0JX+3zoy2uFk7Vn9EfXASOtVmmIVbL3jE/W8Z66VgPSZcMhw==",
-      "requires": {
-        "dom-urls": "^1.1.0",
-        "es6-promise": "^4.0.5",
-        "glob": "^7.1.1",
-        "lodash.defaults": "^4.2.0",
-        "lodash.template": "^4.4.0",
-        "meow": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "pretty-bytes": "^4.0.2",
-        "sw-toolbox": "^3.4.0",
-        "update-notifier": "^2.3.0"
-      }
-    },
-    "sw-toolbox": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
-      "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
-      "requires": {
-        "path-to-regexp": "^1.0.1",
-        "serviceworker-cache-polyfill": "^4.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "path-to-regexp": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-          "requires": {
-            "isarray": "0.0.1"
           }
         }
       }
@@ -15021,11 +14845,6 @@
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.1.tgz",
       "integrity": "sha512-X+eloHbgJGxczUk1WSjIvn7aC9oN3jVE3rQfRVKcgpavi3jxtCn0VVKtjOBj64Yop96UYn/ujJRpTbCdAF1vyg=="
     },
-    "trim-newlines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
-    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -15142,13 +14961,6 @@
         }
       }
     },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
-    },
     "uglifyjs-webpack-plugin": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
@@ -15223,17 +15035,25 @@
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
       "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg=="
     },
+    "unicode-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-regex/-/unicode-regex-2.0.0.tgz",
+      "integrity": "sha512-5nbEG2YU7loyTvPABaKb+8B0u8L7vWCsVmCSsiaO249ZdMKlvrXlxR2ex4TUVAdzv/Cne/TdoXSSaJArGXaleQ==",
+      "dev": true,
+      "requires": {
+        "regexp-util": "^1.2.0"
+      }
+    },
     "unified": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-6.1.6.tgz",
-      "integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
+      "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
       "requires": {
         "bail": "^1.0.0",
         "extend": "^3.0.0",
         "is-plain-obj": "^1.1.0",
         "trough": "^1.0.0",
         "vfile": "^2.0.0",
-        "x-is-function": "^1.0.4",
         "x-is-string": "^0.1.0"
       }
     },
@@ -15397,6 +15217,12 @@
         "dotenv-expand": "^4.2.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+          "dev": true
+        },
         "dotenv": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
@@ -15490,11 +15316,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "urijs": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
-      "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg=="
     },
     "urix": {
       "version": "0.1.0",
@@ -15751,9 +15572,9 @@
       }
     },
     "webpack": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.17.1.tgz",
-      "integrity": "sha512-vdPYogljzWPhFKDj3Gcp01Vqgu7K3IQlybc3XIdKSQHelK1C3eIQuysEUR7MxKJmdandZlQB/9BG2Jb1leJHaw==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.17.2.tgz",
+      "integrity": "sha512-hCK8FPco2Paz9FVMlo3ZdVd7Jsr7qxoiEwhd7f4dMaWBLZtc7E+/9QNee4CYHlVSvpmspWBnhFpx4MiWSl3nNg==",
       "requires": {
         "@webassemblyjs/ast": "1.5.13",
         "@webassemblyjs/helper-module-context": "1.5.13",
@@ -15779,7 +15600,7 @@
         "tapable": "^1.0.0",
         "uglifyjs-webpack-plugin": "^1.2.4",
         "watchpack": "^1.5.0",
-        "webpack-sources": "^1.0.1"
+        "webpack-sources": "^1.2.0"
       },
       "dependencies": {
         "ajv": {
@@ -15834,9 +15655,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.7.tgz",
-      "integrity": "sha512-KagFrNHf3QKndS61cXqzkQ4gpdXo0d1LZTTplAJzNK1Ev2ZyJiu+BzerW/2dixYYfpnGzp0AcvCXpmYXIOkFOA==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.8.tgz",
+      "integrity": "sha512-c+tcJtDqnPdxCAzEEZKdIPmg3i5i7cAHe+B+0xFNK0BlCc2HF/unYccbU7xTgfGc5xxhCztCQzFmsqim+KhI+A==",
       "requires": {
         "ansi-html": "0.0.7",
         "bonjour": "^3.5.0",
@@ -15848,7 +15669,7 @@
         "express": "^4.16.2",
         "html-entities": "^1.2.0",
         "http-proxy-middleware": "~0.18.0",
-        "import-local": "^1.0.0",
+        "import-local": "^2.0.0",
         "internal-ip": "^3.0.1",
         "ip": "^1.1.5",
         "killable": "^1.0.0",
@@ -15865,7 +15686,7 @@
         "supports-color": "^5.1.0",
         "webpack-dev-middleware": "3.2.0",
         "webpack-log": "^2.0.0",
-        "yargs": "12.0.1"
+        "yargs": "12.0.2"
       },
       "dependencies": {
         "ajv": {
@@ -15884,12 +15705,38 @@
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
           "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
         },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
         "decamelize": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
           "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
           "requires": {
             "xregexp": "4.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "fast-deep-equal": {
@@ -15905,10 +15752,23 @@
             "locate-path": "^3.0.0"
           }
         },
+        "invert-kv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+        },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
         },
         "locate-path": {
           "version": "3.0.0",
@@ -15917,6 +15777,26 @@
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
+          }
+        },
+        "mem": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
+          "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^1.0.0",
+            "p-is-promise": "^1.1.0"
+          }
+        },
+        "os-locale": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
+          "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+          "requires": {
+            "execa": "^0.10.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
           }
         },
         "p-limit": {
@@ -15974,15 +15854,15 @@
           }
         },
         "yargs": {
-          "version": "12.0.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
-          "integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
+          "version": "12.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
+          "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
           "requires": {
             "cliui": "^4.0.0",
             "decamelize": "^2.0.0",
             "find-up": "^3.0.0",
             "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
+            "os-locale": "^3.0.0",
             "require-directory": "^2.1.1",
             "require-main-filename": "^1.0.1",
             "set-blocking": "^2.0.0",
@@ -16003,9 +15883,9 @@
       }
     },
     "webpack-hot-middleware": {
-      "version": "2.22.3",
-      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.22.3.tgz",
-      "integrity": "sha512-mrG3bJGX4jgWbrpY0ghIpPgCmNhZziFMBJBmZfpIe6K/P1rWPkdkbGihbCUIufgQ8ruX4txE5/CKSeFNzDcYOw==",
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.23.1.tgz",
+      "integrity": "sha512-oUdCGDHONJrARtqxPSiON4db4dRWUsRiPwD7dYkglrTc3vF7LKa2jncwN0lIVkNwtoCh/yiHVTzz3Hbcux8ikA==",
       "requires": {
         "ansi-html": "0.0.7",
         "html-entities": "^1.2.0",
@@ -16105,16 +15985,164 @@
       }
     },
     "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
-      "optional": true
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
     },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
+    "workbox-background-sync": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-3.4.1.tgz",
+      "integrity": "sha512-Ksb2nCg/2wOyBMhSBqSbtCEwuKaf5sHgTY8HdCxbLIQSzDh9/qZqg+1P11CKlgJmHtje3EK3B8EsrzukZo10xA==",
+      "requires": {
+        "workbox-core": "^3.4.1"
+      }
+    },
+    "workbox-broadcast-cache-update": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.4.1.tgz",
+      "integrity": "sha512-+WPqHFk4ER4RICAMOYrP88yBbiUQ9ZOFNruqwbl9YxGfbADV16OEGmYpIs+Az6HT6DNDCx8eQqtFiaG8N3O11Q==",
+      "requires": {
+        "workbox-core": "^3.4.1"
+      }
+    },
+    "workbox-build": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-3.4.1.tgz",
+      "integrity": "sha512-Qi04XdHjkXbRN0CV5XO1oqDWbJSIm7VYhxmxjtnVcKK8PrMT6rOUFUi9ziDI+8UQgcXbLK4ZChWf2ptZS1/MbA==",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "common-tags": "^1.4.0",
+        "fs-extra": "^4.0.2",
+        "glob": "^7.1.2",
+        "joi": "^11.1.1",
+        "lodash.template": "^4.4.0",
+        "pretty-bytes": "^4.0.2",
+        "workbox-background-sync": "^3.4.1",
+        "workbox-broadcast-cache-update": "^3.4.1",
+        "workbox-cache-expiration": "^3.4.1",
+        "workbox-cacheable-response": "^3.4.1",
+        "workbox-core": "^3.4.1",
+        "workbox-google-analytics": "^3.4.1",
+        "workbox-navigation-preload": "^3.4.1",
+        "workbox-precaching": "^3.4.1",
+        "workbox-range-requests": "^3.4.1",
+        "workbox-routing": "^3.4.1",
+        "workbox-strategies": "^3.4.1",
+        "workbox-streams": "^3.4.1",
+        "workbox-sw": "^3.4.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "joi": {
+          "version": "11.4.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
+          "integrity": "sha512-O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==",
+          "requires": {
+            "hoek": "4.x.x",
+            "isemail": "3.x.x",
+            "topo": "2.x.x"
+          }
+        }
+      }
+    },
+    "workbox-cache-expiration": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-3.4.1.tgz",
+      "integrity": "sha512-AzOPB+dwfxg13v4+q5jWkxsw/oim9mPIzew1anu8ALA3vB8qySaJJToXp+ZlVh/Co+sDK0tgjlB76bvSFHgZ4g==",
+      "requires": {
+        "workbox-core": "^3.4.1"
+      }
+    },
+    "workbox-cacheable-response": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-3.4.1.tgz",
+      "integrity": "sha512-SO2k830JT93GitPwc5tzJI49d9VwyVxXwiCbyvo+Sqo+dcvWSrmpsyuXdzy6zuasbPrWUF0vsFj1uGtZbOym8Q==",
+      "requires": {
+        "workbox-core": "^3.4.1"
+      }
+    },
+    "workbox-core": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-3.4.1.tgz",
+      "integrity": "sha512-RqMV2so9/KLAu9aUxJ/85pvrZMUn835B8zoHmqRyGNetiDr8B1zSBeKXPZAjFlX/88KdhizNwiRlJtqlXtM4tA=="
+    },
+    "workbox-google-analytics": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-3.4.1.tgz",
+      "integrity": "sha512-w6Osz2Rr1/4+W0gram6Yzg6NNWLvHP51RwFCNAZSpEnipr0qSEtD+yvwrdaHfiJHWhcK2yH/V6E1MV8Hrczmvw==",
+      "requires": {
+        "workbox-background-sync": "^3.4.1",
+        "workbox-core": "^3.4.1",
+        "workbox-routing": "^3.4.1",
+        "workbox-strategies": "^3.4.1"
+      }
+    },
+    "workbox-navigation-preload": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-3.4.1.tgz",
+      "integrity": "sha512-P3FHAcyZ8db2QiW/BpMkuosC1OkRsEoUaT7U3QOgg7JSjjsJoEbF7G5olNe+P+PQYdVhJA7TCuptI6dy2gLS/g==",
+      "requires": {
+        "workbox-core": "^3.4.1"
+      }
+    },
+    "workbox-precaching": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-3.4.1.tgz",
+      "integrity": "sha512-ykU2mly9xmRrCW6iMeUWYydWiso/WSE16+7wponhI0WC53jiQSt2JvykWm0VpWFJSs6ZTSZZ1WK2gs/brRnPug==",
+      "requires": {
+        "workbox-core": "^3.4.1"
+      }
+    },
+    "workbox-range-requests": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-3.4.1.tgz",
+      "integrity": "sha512-ktgjl6liZrRTmQjPw1pBblC5umHnTb8XcvFVitdGz17B23jj6cUV4EXzEU2ilGn6jO6+MLV1Vn9SWajtLSc2Gg==",
+      "requires": {
+        "workbox-core": "^3.4.1"
+      }
+    },
+    "workbox-routing": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-3.4.1.tgz",
+      "integrity": "sha512-6j6cXMUYfMPYTycmElxVOfBTr6WV5zAn/JUFJ7GJ5pYFIE9cqztprnrcOsWJ42+AiNIeHPbKfyIWE/rZVviMxQ==",
+      "requires": {
+        "workbox-core": "^3.4.1"
+      }
+    },
+    "workbox-strategies": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-3.4.1.tgz",
+      "integrity": "sha512-7mJuzFsgejflzjfnChXCFma1S0mi9WC6wlSU2wE50M7bJmEuf9A3j3MojpKcsTEM58hbhbnU6QF/u9iIV7+opw==",
+      "requires": {
+        "workbox-core": "^3.4.1"
+      }
+    },
+    "workbox-streams": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-3.4.1.tgz",
+      "integrity": "sha512-krw+5bp+oe9Za5c6WlTWM3SgZGfExYcqRSn1gsyYgKeXmgzTwf+DOb5Lwult0KSWlJfq8B3Wk7sW8Sl7lRzSbA==",
+      "requires": {
+        "workbox-core": "^3.4.1"
+      }
+    },
+    "workbox-sw": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-3.4.1.tgz",
+      "integrity": "sha512-nnm2by5oaQGXRH7x4M5/n2KqjUGVmP4P8azUmJITnYa3DWVYn/ghDg3LJ5+h4A28vYq9V6ePgATaEPfb6B5pug=="
     },
     "worker-farm": {
       "version": "1.6.0",
@@ -16189,7 +16217,8 @@
     "x-is-function": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/x-is-function/-/x-is-function-1.0.4.tgz",
-      "integrity": "sha1-XSlNw9Joy90GJYDgxd93o5HR+h4="
+      "integrity": "sha1-XSlNw9Joy90GJYDgxd93o5HR+h4=",
+      "dev": true
     },
     "x-is-string": {
       "version": "0.1.0",
@@ -16236,12 +16265,28 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
+    "yaml": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.0.0-rc.8.tgz",
+      "integrity": "sha512-+6a1nAiwS141AYKYsGXp9A7uLsYwY5f2ql9BhpewjfLm8u8HYh43ZD+8GWY4FNusZjU5+oa9cg9Spx0orQSf1g==",
+      "dev": true
+    },
     "yaml-loader": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/yaml-loader/-/yaml-loader-0.5.0.tgz",
       "integrity": "sha512-p9QIzcFSNm4mCw/m5NdyMfN4RE4aFZJWRRb01ERVNGCym8VNbKtw3OYZXnvUIkim6U/EjqE/2yIh9F/msShH9A==",
       "requires": {
         "js-yaml": "^3.5.2"
+      }
+    },
+    "yaml-unist-parser": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/yaml-unist-parser/-/yaml-unist-parser-1.0.0-rc.4.tgz",
+      "integrity": "sha512-y09JF17+/tMqr5fF5vP9hQsDy434LTNtpoBPj8pNssnGAnB1susUtTFkM8Cum0N0Gb8yqzp8TorKwrPMEFLP9Q==",
+      "dev": true,
+      "requires": {
+        "lines-and-columns": "^1.1.6",
+        "tslib": "^1.9.1"
       }
     },
     "yargs": {
@@ -16306,7 +16351,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
-    "develop": "gatsby develop",
+    "develop": "rm -rf .cache/ && gatsby develop",
     "serve": "rm -rf ./public && gatsby build && gatsby serve",
     "format": "prettier --write '{,**/}*.{js,json,mdx,css}'",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -6,17 +6,21 @@
   "dependencies": {
     "@mdx-js/mdx": "^0.15.0",
     "@mdx-js/tag": "^0.15.0",
-    "babel-plugin-styled-components": "^1.5.1",
-    "gatsby": "^2.0.0-rc.0",
+    "babel-plugin-styled-components": "^1.6.3",
+    "gatsby": "^2.0.0-rc.13",
     "gatsby-mdx": "^0.1.3",
-    "gatsby-plugin-manifest": "^2.0.2-rc.0",
-    "gatsby-plugin-offline": "^2.0.0-rc.0",
-    "gatsby-plugin-react-helmet": "^3.0.0-rc.0",
-    "gatsby-plugin-styled-components": "^3.0.0-rc.0",
-    "react": "^16.4.2",
-    "react-dom": "^16.4.2",
+    "gatsby-plugin-manifest": "^2.0.2-rc.1",
+    "gatsby-plugin-offline": "^2.0.0-rc.4",
+    "gatsby-plugin-react-helmet": "^3.0.0-rc.1",
+    "gatsby-plugin-styled-components": "^3.0.0-rc.1",
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0",
     "react-helmet": "^5.2.0",
-    "styled-components": "^3.4.2"
+    "styled-components": "^4.0.0-beta.0-2"
+  },
+  "engines": {
+    "node": "^10.6.0",
+    "npm": "^6.4.1"
   },
   "keywords": [
     "gatsby"
@@ -32,8 +36,9 @@
     "pretty-quick": "pretty-quick"
   },
   "devDependencies": {
-    "@storybook/addon-actions": "^4.0.0-alpha.18",
-    "@storybook/react": "^4.0.0-alpha.18",
+    "@storybook/addon-actions": "^4.0.0-alpha.20",
+    "@storybook/react": "^4.0.0-alpha.20",
+    "core-js": "^2.5.7",
     "husky": "^1.0.0-rc.13",
     "prettier": "git+https://github.com/prettier/prettier.git#master",
     "pretty-quick": "^1.6.0"

--- a/src/pages/mdx-index.mdx
+++ b/src/pages/mdx-index.mdx
@@ -1,0 +1,58 @@
+import Layout from '../components/layout'
+import Hero from '../widgets/Hero'
+import CopyLight from '../widgets/CopyLight'
+import CopyLargeImageLeft from '../widgets/CopyLargeImageLeft'
+import CopyLargeImageRight from '../widgets/CopyLargeImageRight'
+import Testimonial from '../widgets/Testimonial'
+import CopySmallImageLeft from '../widgets/CopySmallImageLeft'
+import CopySmallImageRight from '../widgets/CopySmallImageRight'
+import CopyLargeImageRightText from '../../content/CopyLargeImageRightText.mdx'
+import CopyLargeImageLeftText from '../../content/CopyLargeImageLeftText.mdx'
+
+import LeftImage from '../images/gatsby-icon.png'
+import Test1 from '../images/Test1.jpg'
+
+<Hero />
+<CopyLargeImageRight image={LeftImage} copy={<CopyLargeImageRightText />} />
+<CopyLargeImageLeft
+  header="LEARNING A NEW CODING PARADIGM IS HARD"
+  image={LeftImage}
+  copy={<CopyLargeImageLeftText />}
+/>
+<CopyLight
+  header="BECOME A DATA VISUALIZATION ENGINEER WITH REACT+D3V4"
+  copy={
+    <div>
+      <p>
+        React+D3v4 gives you a quick overview of the basics to get you
+        started, followed by a deep dive that solidifies your knowledge
+        through varied projects and examples. Build working code that you
+        can show off to your friends, boss, and coworkers.
+      </p>
+      <p>
+        Learn the basics with interactive examples right in your browser —
+        no need to install anything. Forget about Npm and Webpack and Babel
+        and Node. Just React and D3.
+      </p>
+      <p>
+        Dive into 7 projects that teach you how it all fits together. Build
+        interactive visualizations, create animations, and build fast
+        performance with canvas. Learn everything there is to know about
+        building beautiful apps with React and D3.
+      </p>
+      <p>
+        From the very basics of React and D3, to state handling with Redux
+        and MobX, React alternatives like Preact and Inferno.
+      </p>
+    </div>
+  }
+/>
+<Testimonial
+  image={Test1}
+  quote="You just blew my mind! This is going to save me so much time."
+  name="-- Patrick Davidson, Developer at Phytozome Group, JGI, Lawrence Berkeley Lab"
+/>
+<CopySmallImageLeft />
+<CopySmallImageRight />
+
+export default Layout


### PR DESCRIPTION
This adds a `/content` directory for the mdx copy that then gets fed into widgets and pages.

I've copied and ported the whole `index.js` file to `mdx-index.mdx` and extracted out the `copy` props for the `CopyLargeImage*` widgets as illustration.

I've left `index.js` untouched to make comparison easier, but new edits should go into `mdx-index.mdx` and after they're done we can remove `index.js` and rename `mdx-index.mdx` to `index.mdx`.